### PR TITLE
Fixed broken fb, insta, twitter links

### DIFF
--- a/client/assets/views/index.html
+++ b/client/assets/views/index.html
@@ -486,17 +486,17 @@
 
                     <ul class="social-networks text-right">
                         <li>
-                            <a href="#">
+                            <a href="https://www.instagram.com/emissarycheckin/">
                                 <i class="entypo-instagram"></i>
                             </a>
                         </li>
                         <li>
-                            <a href="#">
+                            <a href="https://twitter.com/UCSanDiego?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor">
                                 <i class="entypo-twitter"></i>
                             </a>
                         </li>
                         <li>
-                            <a href="#">
+                            <a href="https://www.facebook.com/groups/groupsatucsd/">
                                 <i class="entypo-facebook"></i>
                             </a>
                         </li>


### PR DESCRIPTION
Set up an instagram from emissary. Its just screenshots. The fb and twitter links go to ucsd pages. 